### PR TITLE
fix for DefaultProceessController

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 import PackageDescription
 let package = Package(
     name: "CommandLineToolkit",
     platforms: [
-        .macOS(.v10_15),
+        .macOS(.v11),
     ],
     products: [
         .library(name: "AtomicModels", targets: ["AtomicModels"]),

--- a/Sources/ProcessController/DefaultProcessController.swift
+++ b/Sources/ProcessController/DefaultProcessController.swift
@@ -85,7 +85,9 @@ public final class DefaultProcessController: ProcessController, CustomStringConv
         let process = Process()
         process.launchPath = pathToExecutable.pathString
         process.arguments = Array(arguments.dropFirst())
-        process.environment = environment
+        if (!environment.isEmpty) {
+            process.environment = environment
+        }
         process.currentDirectoryPath = workingDirectory.pathString
         try process.setStartsNewProcessGroup(false)
         return process


### PR DESCRIPTION
When I use DefaultProcessController with [applesimutils](https://github.com/wix/AppleSimulatorUtils)
`var processController = DefaultProcessController(
        subprocess: Subprocess(arguments: [
            "/usr/local/bin/applesimutils",
            "-id",
            "EB6808EB-9181-45EF-A31F-668EE42456C0",
            "-b",
            "my.bundle.id",
            "-sp",
            "notifications=YES, photos=YES, camera=YES, userTracking=NO, microphone=YES, location=always"
        ])
    )`

I get exit code 255. I find out that it is because of environment variables that we pass to process. Even default empty array [:] leads to error exit code.
